### PR TITLE
Wrong link in the README: https://www.phoxygen.com/

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We started from the Jekyll implementation of the [Stylish
 Portfolio](http://startbootstrap.com/template-overviews/stylish-portfolio/)
 template by [Start Bootstrap](http://startbootstrap.com/).
 
-See the site in action at https://www.phoxygen.com/
+See the site in action at http://www.phoxygen.com/
 
 ## Dev Workflow
 


### PR DESCRIPTION
Neither https://www.phoxygen.com/ nor https://phoxygen.com/ work right now, and http://phoxygen.com/ redirects to http://www.phoxygen.com/, so let’s use this last URL in the README.md file.

@autra @lcuguen r?
