### PR TITLE
careers.md: spelling and titles

### DIFF
--- a/careers.md
+++ b/careers.md
@@ -3,50 +3,30 @@ layout: technical
 title: Careers at Phoxygen
 ---
 
-# Phoxygen is hiring
+# Phoxygen is hiring!
 
 ## Senior JavaScript Developer
 
 Phoxygen is looking for an experienced JavaScript developer to work on Mozilla technologies. You’ll be fully part of the team that works on Firefox OS.
 
-### Your Mission
+### Mission
 
-- Translate UX designs and wireframes in high quality code
-- Write and maintain efficient, secured and reliable code
-- Make sure to understand and write you code with a sole objective, performance and reactivity of the front-end side
-- Know how to get along with the team and work in an efficient way remotely
-- Identify and fix bugs
-- Work in a peer-review fashion
-- Work with github and bugzilla to fit in the company
+- Develop progressive web applications with optimal efficiency and performance
+- Translate UX designs and wireframes into high-quality code
+- Work remotely with a distributed team of passionate developers
 
-### Your Qualifications
+### Qualifications
 
-- Engineer diploma or equivalent professional experience
-- More than 3 years as a software developer
-- Skilfully written and spoken English — mastering French is a plus.
+- Your open-source repositories are your best recommendation!
+- Engineering degree or equivalent professional experience
+- Successful 3+ year experience as a software developer
+- Proficient HTML/CSS/JS and excellent Vanilla-JS knowledge
+- General knowhow of the web and its best practices
+- Experience with Agile, peer-reviewing and github/bugzilla workflows
+- Remote work experience is a big plus
+- Fluent English — speaking French is a plus
 
-### Technical Abilities
+### Location
 
-- Public, open-source repositories greatly appreciated
-- Ability to write elegant, industrial code
-- Knowledge of the latest JavaScript language development
-- One to two years professional development in JavaScript
-- No need for a specific framework — just plain, vanilla JavaScript
-- General knowhow about the web and its best practices
-
-### Personal Qualities
-
-- Experienced with Agile development
-- Passionate about new technologies and you wish to develop your expertise in bleeding-edge web technologies
-- Open-minded and willing to solve any problem in a positive way
-- Being a teammate and a leader for the rest of the team
-
-### Our work offer can be in any location
-
-- Paris office or remote
-- European timezone
-
-### Advantages
-
-Remote, Vanilla JS, Mozilla Technologies
+Anywhere in the Paris timezone! Our developer team is 100% remote.
 

--- a/careers.md
+++ b/careers.md
@@ -1,52 +1,52 @@
 ---
 layout: technical
-title: Carreers at Phoxygen
+title: Careers at Phoxygen
 ---
 
 # Phoxygen is hiring
 
-## Senior Javascript Developer at Phoxygen
+## Senior JavaScript Developer
 
-The technical team at Phoxygen is looking for experienced Javascript developer to work on Mozilla technologies. You'll be fully part of the team that work on Firefox OS
+Phoxygen is looking for an experienced JavaScript developer to work on Mozilla technologies. You’ll be fully part of the team that works on Firefox OS.
 
-### A few informations regarding your mission:
+### Your Mission
 
-- Translate UX design and wireframe in high quality code
-- Write and maintain performant, secured and reliable code
-- Make sure to understand and write you code with a sole objective, performance and reactivity of the frontend side
+- Translate UX designs and wireframes in high quality code
+- Write and maintain efficient, secured and reliable code
+- Make sure to understand and write you code with a sole objective, performance and reactivity of the front-end side
 - Know how to get along with the team and work in an efficient way remotely
 - Identify and fix bugs
 - Work in a peer-review fashion
-- Leark on workflow like github and bugzilla to fit in the company
+- Work with github and bugzilla to fit in the company
 
-## Your qualification
+### Your Qualifications
 
-- Engineer diploma or equivalent professional experience.
-- More than 3 year as a software developer
-- Skilfully written and spoken english, mastering french is a plus, but not mandatory. Other mastered languages welcome.
+- Engineer diploma or equivalent professional experience
+- More than 3 years as a software developer
+- Skilfully written and spoken English — mastering French is a plus.
 
-## Technical abilities
+### Technical Abilities
 
-- One or more git opensource repository greatly appreciated
-- Being able to wirte elegante, industrial code.
-- Knowledge of the latest javascript language development
-- One to two years professional development in Javascript
-- No need for a specific framework, just plain, vanilla javascript
-- General knowhow about the web, and its best practices
+- Public, open-source repositories greatly appreciated
+- Ability to write elegant, industrial code
+- Knowledge of the latest JavaScript language development
+- One to two years professional development in JavaScript
+- No need for a specific framework — just plain, vanilla JavaScript
+- General knowhow about the web and its best practices
 
-## Personnal qualities
+### Personal Qualities
 
-- Experienced with agile development in a team
-- Passionnate about new technologies and you wish to develop your expertise in bleeding edge web technologies
-- Openminded and willing to solve any problems in a positive way.
-- Being a teammat and a leader for the rest of the team
+- Experienced with Agile development
+- Passionate about new technologies and you wish to develop your expertise in bleeding-edge web technologies
+- Open-minded and willing to solve any problem in a positive way
+- Being a teammate and a leader for the rest of the team
 
-## Our work offer can be in any location
+### Our work offer can be in any location
 
 - Paris office or remote
 - European timezone
 
-## Avantages
+### Advantages
 
 Remote, Vanilla JS, Mozilla Technologies
 


### PR DESCRIPTION
Fixing the title hierarchy and the most obvious spelling mistakes.

IMHO, this page really needs some proof-reading — and not only for grammatical reasons. I remember the team wrote an etherpad for this front-end dev job offer, and it looks like it hasn’t been taken into account.
