### PR TITLE
make the banner link point to the homepage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: Phoxygen
 email: contact@phoxygen.com
 description: Building Firefox OS!
-baseurl: ''       # the subpath of your site, e.g. /blog/
+baseurl: '/'      # the subpath of your site, e.g. /blog/
 host: '127.0.0.1' # the base hostname & protocol for your site
 port: 4000
 phoxygen_image: /img/phoxygen-transparent.png

--- a/_layouts/technical.html
+++ b/_layouts/technical.html
@@ -4,12 +4,11 @@
   {% include head.html %}
 
   <body>
-
     {% include navigation.html %}
     {% include header-technical.html %}
     <div class="container technical">
       <div class="text-vertical-left">
-      {{ content }}
+        {{ content }}
       </div>
     </div>
     {% include footer.html %}


### PR DESCRIPTION
in the `technical` pages, the main banner link points to the page itself, which is probably not the intended behavior. Here’s a quick fix.

@autra r?
