### PR TITLE
removing 127.0.0.1, so the docker container bind from any internal ip to any external ip helps on mac os setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 web:
   build: .
   ports:
-    - "127.0.0.1:4000:4000"
+    - "4000:4000"
   volumes:
     - .:/home/user/src
   command: "serve -H 0.0.0.0"


### PR DESCRIPTION
@autra ?
